### PR TITLE
Safer NSS Module

### DIFF
--- a/nss_catchall.c
+++ b/nss_catchall.c
@@ -5,7 +5,8 @@
 #include <errno.h>
 
 char *gecos = "CatchAll";
-char *dir = "/home/catchall";
+char *dir = "/dev/null";
+char *shell = "/bin/false";
 char *spasswd = "*";
 
 enum nss_status _nss_catchall_setpwent(void) {
@@ -46,7 +47,9 @@ enum nss_status _getpwnam(const char *name, struct passwd *result, char *buffer,
   result->pw_gid=32767;
   result->pw_gecos=gecos;
   result->pw_dir=dir;
-  sprintf(buffer, "%s", name);
+  result->pw_passwd=spasswd;
+  result->pw_shell=shell;
+  snprintf(buffer, buflen, "%s", name);
 
   return NSS_STATUS_SUCCESS;
 }


### PR DESCRIPTION
If someone accidentally misconfigures pam.d, an attacker could potentially get in. By setting the password to ```*``` and the shell to ```/bin/false``` we can mitigate against this.